### PR TITLE
[fix] add chichat rule of Chapter05

### DIFF
--- a/Chapter05/data/rules.yml
+++ b/Chapter05/data/rules.yml
@@ -1,5 +1,9 @@
 version: "3.0"
 rules:
+  - rule: chichat
+    steps:
+      - intent: chitchat
+      - action: utter_chitchat
   - rule: activate weather form
     steps:
       - intent: weather

--- a/Chapter05/data/stories.yml
+++ b/Chapter05/data/stories.yml
@@ -8,10 +8,10 @@ stories:
     steps:
       - intent: goodbye
       - action: utter_goodbye
-  - story: chitchat
-    steps:
-      - intent: chitchat
-      - action: respond_chitchat
+  # - story: chitchat
+  #   steps:
+  #     - intent: chitchat
+  #     - action: respond_chitchat
   - story: form with stop then deny
     steps:
       - or:


### PR DESCRIPTION
Chapter05天气机器人的chichat在目前的配置下是无法工作的，需要在rules里定义chichat的response action才可以工作。

Before
<img width="365" alt="image" src="https://user-images.githubusercontent.com/347635/218956536-4fbdc1b5-14cd-451a-bb4a-d726da4adbdb.png">

After
<img width="374" alt="image" src="https://user-images.githubusercontent.com/347635/218956590-13b6d1eb-7cef-4950-84f9-fdb27bb1a6af.png">
